### PR TITLE
Replace upstime in days with timestamp

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -181,8 +181,8 @@ mqtt:
 # uptime
    -  name: OpenWRT uptime
       state_topic: collectd/<Open-WRT-Hostname>/uptime/uptime
-      unit_of_measurement: days
-      value_template: "{{ (value.split(':')[1].split('\x00')[0] | float / 86400) | round(1) }}"
+      device_class: timestamp
+      value_template: "{{ as_datetime( (value.split(':')[0] | float ) - (value.split(':')[1].split('\x00')[0] | float ) ) }}"
       unique_id: ap_uptime
       device:
         identifiers: WRT7800


### PR DESCRIPTION
I'm using the following to track the uptime of my OpenWRT router. 

Using a timestamp sensor has the advantage that it always will stay the same and not update on every refresh (or at least change not that often - there might be some decimals that trigger changes).

![Screenshot 2024-07-04 205125](https://github.com/lukdwo/OpenWRT-collectd-MQTT-HA/assets/42204099/c3fa5195-d19c-4d02-bfa6-190422859577)
![image](https://github.com/lukdwo/OpenWRT-collectd-MQTT-HA/assets/42204099/913325ef-1e00-44f1-b960-80305cd7777d)
